### PR TITLE
# ADD - Sender 객체에 sendToMerger, sendToSigner 추가

### DIFF
--- a/network/rpc_services/protos/general_service.pb.cc
+++ b/network/rpc_services/protos/general_service.pb.cc
@@ -126,6 +126,8 @@ const ::google::protobuf::uint32 TableStruct::offsets[] GOOGLE_PROTOBUF_ATTRIBUT
   ~0u,  // no _extensions_
   ~0u,  // no _oneof_case_
   ~0u,  // no _weak_field_map_
+  GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::grpc_general::RequestMsg, broadcast_),
+  GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::grpc_general::RequestMsg, message_id_),
   GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::grpc_general::RequestMsg, message_),
   ~0u,  // no _has_bits_
   GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::grpc_general::MsgStatus, _internal_metadata_),
@@ -139,7 +141,7 @@ static const ::google::protobuf::internal::MigrationSchema schemas[] GOOGLE_PROT
   { 0, -1, sizeof(::grpc_general::Identity)},
   { 6, -1, sizeof(::grpc_general::ReplyMsg)},
   { 12, -1, sizeof(::grpc_general::RequestMsg)},
-  { 18, -1, sizeof(::grpc_general::MsgStatus)},
+  { 20, -1, sizeof(::grpc_general::MsgStatus)},
 };
 
 static ::google::protobuf::Message const * const file_default_instances[] = {
@@ -172,19 +174,20 @@ void AddDescriptorsImpl() {
   static const char descriptor[] GOOGLE_PROTOBUF_ATTRIBUTE_SECTION_VARIABLE(protodesc_cold) = {
       "\n\025general_service.proto\022\014grpc_general\"\032\n"
       "\010Identity\022\016\n\006sender\030\001 \001(\014\"\033\n\010ReplyMsg\022\017\n"
-      "\007message\030\001 \001(\014\"\035\n\nRequestMsg\022\017\n\007message\030"
-      "\001 \001(\014\"~\n\tMsgStatus\022.\n\006status\030\001 \001(\0162\036.grp"
-      "c_general.MsgStatus.Status\022\017\n\007message\030\002 "
-      "\001(\t\"0\n\006Status\022\013\n\007SUCCESS\020\000\022\013\n\007INVALID\020\001\022"
-      "\014\n\010INTERNAL\020\0022\241\001\n\023GruutGeneralService\022C\n"
-      "\013OpenChannel\022\026.grpc_general.Identity\032\026.g"
-      "rpc_general.ReplyMsg\"\000(\0010\001\022E\n\016GeneralSer"
-      "vice\022\030.grpc_general.RequestMsg\032\027.grpc_ge"
-      "neral.MsgStatus\"\000B0\n\036com.gruutnetworks.g"
-      "ruutgeneralB\014GruutNetworkP\001b\006proto3"
+      "\007message\030\001 \001(\014\"D\n\nRequestMsg\022\021\n\tbroadcas"
+      "t\030\001 \001(\010\022\022\n\nmessage_id\030\002 \001(\t\022\017\n\007message\030\003"
+      " \001(\014\"~\n\tMsgStatus\022.\n\006status\030\001 \001(\0162\036.grpc"
+      "_general.MsgStatus.Status\022\017\n\007message\030\002 \001"
+      "(\t\"0\n\006Status\022\013\n\007SUCCESS\020\000\022\013\n\007INVALID\020\001\022\014"
+      "\n\010INTERNAL\020\0022\241\001\n\023GruutGeneralService\022C\n\013"
+      "OpenChannel\022\026.grpc_general.Identity\032\026.gr"
+      "pc_general.ReplyMsg\"\000(\0010\001\022E\n\016GeneralServ"
+      "ice\022\030.grpc_general.RequestMsg\032\027.grpc_gen"
+      "eral.MsgStatus\"\000B0\n\036com.gruutnetworks.gr"
+      "uutgeneralB\014GruutNetworkP\001b\006proto3"
   };
   ::google::protobuf::DescriptorPool::InternalAddGeneratedFile(
-      descriptor, 475);
+      descriptor, 514);
   ::google::protobuf::MessageFactory::InternalRegisterGeneratedFile(
     "general_service.proto", &protobuf_RegisterTypes);
 }
@@ -690,6 +693,8 @@ void ReplyMsg::InternalSwap(ReplyMsg* other) {
 void RequestMsg::InitAsDefaultInstance() {
 }
 #if !defined(_MSC_VER) || _MSC_VER >= 1900
+const int RequestMsg::kBroadcastFieldNumber;
+const int RequestMsg::kMessageIdFieldNumber;
 const int RequestMsg::kMessageFieldNumber;
 #endif  // !defined(_MSC_VER) || _MSC_VER >= 1900
 
@@ -704,15 +709,22 @@ RequestMsg::RequestMsg(const RequestMsg& from)
   : ::google::protobuf::Message(),
       _internal_metadata_(NULL) {
   _internal_metadata_.MergeFrom(from._internal_metadata_);
+  message_id_.UnsafeSetDefault(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
+  if (from.message_id().size() > 0) {
+    message_id_.AssignWithDefault(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), from.message_id_);
+  }
   message_.UnsafeSetDefault(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
   if (from.message().size() > 0) {
     message_.AssignWithDefault(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), from.message_);
   }
+  broadcast_ = from.broadcast_;
   // @@protoc_insertion_point(copy_constructor:grpc_general.RequestMsg)
 }
 
 void RequestMsg::SharedCtor() {
+  message_id_.UnsafeSetDefault(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
   message_.UnsafeSetDefault(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
+  broadcast_ = false;
 }
 
 RequestMsg::~RequestMsg() {
@@ -721,6 +733,7 @@ RequestMsg::~RequestMsg() {
 }
 
 void RequestMsg::SharedDtor() {
+  message_id_.DestroyNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
   message_.DestroyNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
 }
 
@@ -744,7 +757,9 @@ void RequestMsg::Clear() {
   // Prevent compiler warnings about cached_has_bits being unused
   (void) cached_has_bits;
 
+  message_id_.ClearToEmptyNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
   message_.ClearToEmptyNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
+  broadcast_ = false;
   _internal_metadata_.Clear();
 }
 
@@ -758,10 +773,40 @@ bool RequestMsg::MergePartialFromCodedStream(
     tag = p.first;
     if (!p.second) goto handle_unusual;
     switch (::google::protobuf::internal::WireFormatLite::GetTagFieldNumber(tag)) {
-      // bytes message = 1;
+      // bool broadcast = 1;
       case 1: {
         if (static_cast< ::google::protobuf::uint8>(tag) ==
-            static_cast< ::google::protobuf::uint8>(10u /* 10 & 0xFF */)) {
+            static_cast< ::google::protobuf::uint8>(8u /* 8 & 0xFF */)) {
+
+          DO_((::google::protobuf::internal::WireFormatLite::ReadPrimitive<
+                   bool, ::google::protobuf::internal::WireFormatLite::TYPE_BOOL>(
+                 input, &broadcast_)));
+        } else {
+          goto handle_unusual;
+        }
+        break;
+      }
+
+      // string message_id = 2;
+      case 2: {
+        if (static_cast< ::google::protobuf::uint8>(tag) ==
+            static_cast< ::google::protobuf::uint8>(18u /* 18 & 0xFF */)) {
+          DO_(::google::protobuf::internal::WireFormatLite::ReadString(
+                input, this->mutable_message_id()));
+          DO_(::google::protobuf::internal::WireFormatLite::VerifyUtf8String(
+            this->message_id().data(), static_cast<int>(this->message_id().length()),
+            ::google::protobuf::internal::WireFormatLite::PARSE,
+            "grpc_general.RequestMsg.message_id"));
+        } else {
+          goto handle_unusual;
+        }
+        break;
+      }
+
+      // bytes message = 3;
+      case 3: {
+        if (static_cast< ::google::protobuf::uint8>(tag) ==
+            static_cast< ::google::protobuf::uint8>(26u /* 26 & 0xFF */)) {
           DO_(::google::protobuf::internal::WireFormatLite::ReadBytes(
                 input, this->mutable_message()));
         } else {
@@ -796,10 +841,25 @@ void RequestMsg::SerializeWithCachedSizes(
   ::google::protobuf::uint32 cached_has_bits = 0;
   (void) cached_has_bits;
 
-  // bytes message = 1;
+  // bool broadcast = 1;
+  if (this->broadcast() != 0) {
+    ::google::protobuf::internal::WireFormatLite::WriteBool(1, this->broadcast(), output);
+  }
+
+  // string message_id = 2;
+  if (this->message_id().size() > 0) {
+    ::google::protobuf::internal::WireFormatLite::VerifyUtf8String(
+      this->message_id().data(), static_cast<int>(this->message_id().length()),
+      ::google::protobuf::internal::WireFormatLite::SERIALIZE,
+      "grpc_general.RequestMsg.message_id");
+    ::google::protobuf::internal::WireFormatLite::WriteStringMaybeAliased(
+      2, this->message_id(), output);
+  }
+
+  // bytes message = 3;
   if (this->message().size() > 0) {
     ::google::protobuf::internal::WireFormatLite::WriteBytesMaybeAliased(
-      1, this->message(), output);
+      3, this->message(), output);
   }
 
   if ((_internal_metadata_.have_unknown_fields() &&  ::google::protobuf::internal::GetProto3PreserveUnknownsDefault())) {
@@ -816,11 +876,27 @@ void RequestMsg::SerializeWithCachedSizes(
   ::google::protobuf::uint32 cached_has_bits = 0;
   (void) cached_has_bits;
 
-  // bytes message = 1;
+  // bool broadcast = 1;
+  if (this->broadcast() != 0) {
+    target = ::google::protobuf::internal::WireFormatLite::WriteBoolToArray(1, this->broadcast(), target);
+  }
+
+  // string message_id = 2;
+  if (this->message_id().size() > 0) {
+    ::google::protobuf::internal::WireFormatLite::VerifyUtf8String(
+      this->message_id().data(), static_cast<int>(this->message_id().length()),
+      ::google::protobuf::internal::WireFormatLite::SERIALIZE,
+      "grpc_general.RequestMsg.message_id");
+    target =
+      ::google::protobuf::internal::WireFormatLite::WriteStringToArray(
+        2, this->message_id(), target);
+  }
+
+  // bytes message = 3;
   if (this->message().size() > 0) {
     target =
       ::google::protobuf::internal::WireFormatLite::WriteBytesToArray(
-        1, this->message(), target);
+        3, this->message(), target);
   }
 
   if ((_internal_metadata_.have_unknown_fields() &&  ::google::protobuf::internal::GetProto3PreserveUnknownsDefault())) {
@@ -840,11 +916,23 @@ size_t RequestMsg::ByteSizeLong() const {
       ::google::protobuf::internal::WireFormat::ComputeUnknownFieldsSize(
         (::google::protobuf::internal::GetProto3PreserveUnknownsDefault()   ? _internal_metadata_.unknown_fields()   : _internal_metadata_.default_instance()));
   }
-  // bytes message = 1;
+  // string message_id = 2;
+  if (this->message_id().size() > 0) {
+    total_size += 1 +
+      ::google::protobuf::internal::WireFormatLite::StringSize(
+        this->message_id());
+  }
+
+  // bytes message = 3;
   if (this->message().size() > 0) {
     total_size += 1 +
       ::google::protobuf::internal::WireFormatLite::BytesSize(
         this->message());
+  }
+
+  // bool broadcast = 1;
+  if (this->broadcast() != 0) {
+    total_size += 1 + 1;
   }
 
   int cached_size = ::google::protobuf::internal::ToCachedSize(total_size);
@@ -874,9 +962,16 @@ void RequestMsg::MergeFrom(const RequestMsg& from) {
   ::google::protobuf::uint32 cached_has_bits = 0;
   (void) cached_has_bits;
 
+  if (from.message_id().size() > 0) {
+
+    message_id_.AssignWithDefault(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), from.message_id_);
+  }
   if (from.message().size() > 0) {
 
     message_.AssignWithDefault(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), from.message_);
+  }
+  if (from.broadcast() != 0) {
+    set_broadcast(from.broadcast());
   }
 }
 
@@ -904,8 +999,11 @@ void RequestMsg::Swap(RequestMsg* other) {
 }
 void RequestMsg::InternalSwap(RequestMsg* other) {
   using std::swap;
+  message_id_.Swap(&other->message_id_, &::google::protobuf::internal::GetEmptyStringAlreadyInited(),
+    GetArenaNoVirtual());
   message_.Swap(&other->message_, &::google::protobuf::internal::GetEmptyStringAlreadyInited(),
     GetArenaNoVirtual());
+  swap(broadcast_, other->broadcast_);
   _internal_metadata_.Swap(&other->_internal_metadata_);
 }
 

--- a/network/rpc_services/protos/general_service.pb.h
+++ b/network/rpc_services/protos/general_service.pb.h
@@ -403,9 +403,23 @@ class RequestMsg : public ::google::protobuf::Message /* @@protoc_insertion_poin
 
   // accessors -------------------------------------------------------
 
-  // bytes message = 1;
+  // string message_id = 2;
+  void clear_message_id();
+  static const int kMessageIdFieldNumber = 2;
+  const ::std::string& message_id() const;
+  void set_message_id(const ::std::string& value);
+  #if LANG_CXX11
+  void set_message_id(::std::string&& value);
+  #endif
+  void set_message_id(const char* value);
+  void set_message_id(const char* value, size_t size);
+  ::std::string* mutable_message_id();
+  ::std::string* release_message_id();
+  void set_allocated_message_id(::std::string* message_id);
+
+  // bytes message = 3;
   void clear_message();
-  static const int kMessageFieldNumber = 1;
+  static const int kMessageFieldNumber = 3;
   const ::std::string& message() const;
   void set_message(const ::std::string& value);
   #if LANG_CXX11
@@ -417,11 +431,19 @@ class RequestMsg : public ::google::protobuf::Message /* @@protoc_insertion_poin
   ::std::string* release_message();
   void set_allocated_message(::std::string* message);
 
+  // bool broadcast = 1;
+  void clear_broadcast();
+  static const int kBroadcastFieldNumber = 1;
+  bool broadcast() const;
+  void set_broadcast(bool value);
+
   // @@protoc_insertion_point(class_scope:grpc_general.RequestMsg)
  private:
 
   ::google::protobuf::internal::InternalMetadataWithArena _internal_metadata_;
+  ::google::protobuf::internal::ArenaStringPtr message_id_;
   ::google::protobuf::internal::ArenaStringPtr message_;
+  bool broadcast_;
   mutable ::google::protobuf::internal::CachedSize _cached_size_;
   friend struct ::protobuf_general_5fservice_2eproto::TableStruct;
 };
@@ -696,7 +718,74 @@ inline void ReplyMsg::set_allocated_message(::std::string* message) {
 
 // RequestMsg
 
-// bytes message = 1;
+// bool broadcast = 1;
+inline void RequestMsg::clear_broadcast() {
+  broadcast_ = false;
+}
+inline bool RequestMsg::broadcast() const {
+  // @@protoc_insertion_point(field_get:grpc_general.RequestMsg.broadcast)
+  return broadcast_;
+}
+inline void RequestMsg::set_broadcast(bool value) {
+  
+  broadcast_ = value;
+  // @@protoc_insertion_point(field_set:grpc_general.RequestMsg.broadcast)
+}
+
+// string message_id = 2;
+inline void RequestMsg::clear_message_id() {
+  message_id_.ClearToEmptyNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
+}
+inline const ::std::string& RequestMsg::message_id() const {
+  // @@protoc_insertion_point(field_get:grpc_general.RequestMsg.message_id)
+  return message_id_.GetNoArena();
+}
+inline void RequestMsg::set_message_id(const ::std::string& value) {
+  
+  message_id_.SetNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), value);
+  // @@protoc_insertion_point(field_set:grpc_general.RequestMsg.message_id)
+}
+#if LANG_CXX11
+inline void RequestMsg::set_message_id(::std::string&& value) {
+  
+  message_id_.SetNoArena(
+    &::google::protobuf::internal::GetEmptyStringAlreadyInited(), ::std::move(value));
+  // @@protoc_insertion_point(field_set_rvalue:grpc_general.RequestMsg.message_id)
+}
+#endif
+inline void RequestMsg::set_message_id(const char* value) {
+  GOOGLE_DCHECK(value != NULL);
+  
+  message_id_.SetNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), ::std::string(value));
+  // @@protoc_insertion_point(field_set_char:grpc_general.RequestMsg.message_id)
+}
+inline void RequestMsg::set_message_id(const char* value, size_t size) {
+  
+  message_id_.SetNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited(),
+      ::std::string(reinterpret_cast<const char*>(value), size));
+  // @@protoc_insertion_point(field_set_pointer:grpc_general.RequestMsg.message_id)
+}
+inline ::std::string* RequestMsg::mutable_message_id() {
+  
+  // @@protoc_insertion_point(field_mutable:grpc_general.RequestMsg.message_id)
+  return message_id_.MutableNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
+}
+inline ::std::string* RequestMsg::release_message_id() {
+  // @@protoc_insertion_point(field_release:grpc_general.RequestMsg.message_id)
+  
+  return message_id_.ReleaseNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
+}
+inline void RequestMsg::set_allocated_message_id(::std::string* message_id) {
+  if (message_id != NULL) {
+    
+  } else {
+    
+  }
+  message_id_.SetAllocatedNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), message_id);
+  // @@protoc_insertion_point(field_set_allocated:grpc_general.RequestMsg.message_id)
+}
+
+// bytes message = 3;
 inline void RequestMsg::clear_message() {
   message_.ClearToEmptyNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
 }

--- a/network/rpc_services/protos/general_service.proto
+++ b/network/rpc_services/protos/general_service.proto
@@ -20,7 +20,7 @@ message ReplyMsg {
 
 message RequestMsg {
     bool broadcast = 1;
-    string messageID =2;
+    string message_id =2;
     bytes message = 3;
 }
 

--- a/network/rpc_services/rpc_services.cpp
+++ b/network/rpc_services/rpc_services.cpp
@@ -61,6 +61,8 @@ void GeneralService::proceed() {
 		std::string packed_msg = m_request.message();
 
 		//TODO: MessageHandler handle message
+		//MessageHandler의 처리 상황에 따라 Status값 바뀔 것.
+		rpc_status = Status::OK;
 
 		if(rpc_status.ok()){
 		  m_reply.set_status(grpc_general::MsgStatus_Status_SUCCESS); // SUCCESS

--- a/network/sender.hpp
+++ b/network/sender.hpp
@@ -13,9 +13,12 @@ public:
   PongData pingReq(const std::string &receiver_addr, const std::string &receiver_port);
   NeighborsData findNodeReq(const std::string &receiver_addr, const std::string &receiver_port, const Node::IdType &target_id);
 
-private:
-  std::unique_ptr< KademliaService::Stub> genKademliaStub(const std::string &addr, const std::string &port);
+  void sendToMerger(std::vector<IpEndpoint> &addr_list, std::string &packed_msg, std::string &msg_id, bool broadcast = false);
+  void sendToSigner(std::vector<SignerRpcInfo> &signer_list, std::vector<string> &packed_msg);
 
+private:
+  template<typename TStub, typename TService>
+  std::unique_ptr<TStub> genStub(const std::string &addr, const std::string &port);
 };
 
 }


### PR DESCRIPTION
 # 수정사항
- GeneralRpcService Protobuf 수정
  - 메시지의 broadcast 여부를 판단 할 수 있도록  'broadcast' (boolean) 와 'message_id'(string) 추가
  - 'message_id'는 이미 보낸(포워딩) 메시지를 다시 보내지 않도록 체크하기 위한 message의 고유값

# 추가사항
- genKademliaStub -> genStub ( Template 로 수정)
- sendToMerger ( Merger에게 message를 전송)
- sendToSigner ( Signer에게 message를 전송) 