### PR TITLE
# ADD - Broadcast 메시지확인 테이블 추가

### DIFF
--- a/network/network_engine.cpp
+++ b/network/network_engine.cpp
@@ -9,10 +9,13 @@ NetworkEngine::NetworkEngine() {
   //TODO : 자신의 ID를 인증서버로 부터 받아 올 수 있을 떄 수정 될 것.
   Node my_node(Hash<160>::sha1(MY_ID), MY_ID, IP_ADDRESS, DEFAULT_PORT_NUM);
   m_routing_table = std::make_shared<RoutingTable>(my_node, KBUCKET_SIZE);
+
+  m_broadcast_check_table = std::make_shared<std::set<string>>();
 }
 
 void NetworkEngine::setUp(){
-  m_rpc_server.setUp(m_signer_conn_table, m_routing_table);
+  m_rpc_server.setUp(m_signer_conn_table, m_routing_table, m_broadcast_check_table);
+  m_sender.setUp(m_broadcast_check_table);
 }
 
 void NetworkEngine::run() {

--- a/network/network_engine.hpp
+++ b/network/network_engine.hpp
@@ -1,6 +1,7 @@
 #pragma once
 #include "rpc_server.hpp"
 #include "sender.hpp"
+#include <set>
 
 namespace gruut {
 namespace net {
@@ -20,6 +21,7 @@ public:
 private:
   std::shared_ptr<SignerConnTable> m_signer_conn_table;
   std::shared_ptr<RoutingTable> m_routing_table;
+  std::shared_ptr<std::set<string>> m_broadcast_check_table;
 
   Sender m_sender;
   RpcServer m_rpc_server;

--- a/network/rpc_server.cpp
+++ b/network/rpc_server.cpp
@@ -5,16 +5,18 @@ namespace gruut {
 namespace net {
 
 void RpcServer::setUp(std::shared_ptr<SignerConnTable> signer_conn_table,
-                      std::shared_ptr<RoutingTable> routing_table) {
+                      std::shared_ptr<RoutingTable> routing_table,
+                      std::shared_ptr<std::set<string>> broadcast_check_table) {
 
   m_signer_conn_table = std::move(signer_conn_table);
   m_routing_table = std::move(routing_table);
+  m_broadcast_check_table = std::move(broadcast_check_table);
 }
 
 void RpcServer::initService() {
 
   new OpenChannel(&m_general_service, m_completion_queue.get(), m_signer_conn_table);
-  new GeneralService(&m_general_service, m_completion_queue.get(), m_routing_table);
+  new GeneralService(&m_general_service, m_completion_queue.get(), m_routing_table, m_broadcast_check_table);
 
   new FindNode(&m_kademlia_service, m_completion_queue.get(), m_routing_table);
   new PingPong(&m_kademlia_service, m_completion_queue.get(), m_routing_table);

--- a/network/rpc_server.hpp
+++ b/network/rpc_server.hpp
@@ -2,6 +2,7 @@
 
 #include "rpc_services/rpc_services.hpp"
 #include <string>
+#include <set>
 
 namespace gruut {
 namespace net {
@@ -14,13 +15,15 @@ public:
   }
 
   void setUp(std::shared_ptr<SignerConnTable> signer_conn_table,
-  			 std::shared_ptr<RoutingTable> routing_table);
+  			 std::shared_ptr<RoutingTable> routing_table,
+  			 std::shared_ptr<std::set<string>> broadcast_check_table);
 
   void run(const std::string &port_num);
 
 private:
   std::shared_ptr<SignerConnTable> m_signer_conn_table;
   std::shared_ptr<RoutingTable> m_routing_table;
+  std::shared_ptr<std::set<string>> m_broadcast_check_table;
 
   std::string m_port_num;
   std::unique_ptr<Server> m_server;

--- a/network/rpc_services/rpc_services.hpp
+++ b/network/rpc_services/rpc_services.hpp
@@ -73,8 +73,10 @@ class GeneralService final :public CallData {
 public:
   GeneralService(GruutGeneralService::AsyncService *service,
 				 ServerCompletionQueue *cq,
-				 std::shared_ptr<RoutingTable> routing_table)
-	  : m_responder(&m_context), m_routing_table(std::move(routing_table)){
+				 std::shared_ptr<RoutingTable> routing_table,
+				 std::shared_ptr<std::set<string>> broadcast_check_table)
+	  : m_responder(&m_context), m_routing_table(std::move(routing_table)),
+	    m_broadcast_check_table(std::move(broadcast_check_table)){
 
     m_service = service;
 	m_completion_queue = cq;
@@ -89,6 +91,7 @@ private:
   grpc_general::MsgStatus m_reply;
   ServerAsyncResponseWriter<grpc_general::MsgStatus> m_responder;
 
+  std::shared_ptr<std::set<string>> m_broadcast_check_table;
   std::shared_ptr<RoutingTable> m_routing_table;
   void proceed() override;
 };

--- a/network/sender.cpp
+++ b/network/sender.cpp
@@ -3,6 +3,11 @@
 namespace gruut{
 namespace net{
 
+void Sender::setUp(std::shared_ptr<std::set<string>> broadcast_check_table){
+
+  m_broadcast_check_table  = std::move(broadcast_check_table);
+}
+
 template<typename TStub, typename TService>
 std::unique_ptr<TStub> Sender::genStub(const std::string &addr, const std::string &port) {
 
@@ -63,10 +68,9 @@ NeighborsData Sender::findNodeReq(const std::string &receiver_addr,
   return NeighborsData{ neighbor_list, neighbors.time_stamp(), status};
 }
 
-
 void Sender::sendToMerger(std::vector<IpEndpoint> &addr_list,
                           std::string &packed_msg,
-                          std::string &msg_id,
+                          const std::string &msg_id,
                           bool broadcast) {
 
   RequestMsg req_msg;
@@ -105,6 +109,8 @@ void Sender::sendToMerger(std::vector<IpEndpoint> &addr_list,
      }
   }
 }
+
+
 void Sender::sendToSigner(std::vector<SignerRpcInfo> &signer_list, std::vector<string> &packed_msg){
 
   if(signer_list.size() != packed_msg.size())

--- a/network/sender.hpp
+++ b/network/sender.hpp
@@ -2,6 +2,7 @@
 
 #include "rpc_services/rpc_services.hpp"
 #include <vector>
+#include <set>
 
 namespace gruut{
 namespace net{
@@ -13,10 +14,14 @@ public:
   PongData pingReq(const std::string &receiver_addr, const std::string &receiver_port);
   NeighborsData findNodeReq(const std::string &receiver_addr, const std::string &receiver_port, const Node::IdType &target_id);
 
-  void sendToMerger(std::vector<IpEndpoint> &addr_list, std::string &packed_msg, std::string &msg_id, bool broadcast = false);
+  void sendToMerger(std::vector<IpEndpoint> &addr_list, std::string &packed_msg, const std::string &msg_id = {}, bool broadcast = false);
   void sendToSigner(std::vector<SignerRpcInfo> &signer_list, std::vector<string> &packed_msg);
 
+  void setUp(std::shared_ptr<std::set<string>> broadcast_check_table);
+
 private:
+  std::shared_ptr<std::set<string>> m_broadcast_check_table;
+
   template<typename TStub, typename TService>
   std::unique_ptr<TStub> genStub(const std::string &addr, const std::string &port);
 };

--- a/tests/kademlia_test.cpp
+++ b/tests/kademlia_test.cpp
@@ -68,8 +68,11 @@ BOOST_AUTO_TEST_SUITE(Test_KademliaService)
 	  	std::shared_ptr<SignerConnTable> signer_table =
 	  		std::make_shared<SignerConnTable>();
 
+	  	std::shared_ptr<std::set<string>> broadcast_check_table =
+	  		std::make_shared<std::set<string>>();
+
 	  	RpcServer rpc_server;
-	  	rpc_server.setUp(signer_table, routing_table);
+	  	rpc_server.setUp(signer_table, routing_table, broadcast_check_table);
 
 	  	rpc_server.run(TEST_PORT);
 	});


### PR DESCRIPTION
 # 필요한 이유
- Broadcast(forwarding) 시 자신이 해당 메시지를 다시 받을 수 도 있기때문에 이를 처리할 수단이 필요하다.
- Broadcast 메시지에 ID를 붙여 보낸 후, 그 ID를 보관해 놓은 후 다시 받았을 경우 Table안에 해당 ID가 있으면 자신이 broadcast(forwarding) 한 메시지이므로 드랍 하도록 한다.

# 추가사항
- broadcast_check_table ( std::set  자료구조는 바뀔 수 있음 )
- General rpc를 받았을 때, broadcast 여부를 확인한 후 forwarding 할 수 있도록 함.

# 해야할 일
- table에 계속 무제한으로 저장할 수 없으므로, 주기적으로 해당 table을 clear 해줄 필요가 있음.