### PR TITLE
 # EDIT - HttpClient Constructor 수정

### DIFF
--- a/network/http_client.cpp
+++ b/network/http_client.cpp
@@ -3,13 +3,13 @@
 namespace gruut{
 namespace net {
 
-CURLcode HttpClient::post(const std::string &packed_msg) {
+CURLcode HttpClient::post(const std::string &url_addr, const std::string &json_dump) {
   try {
-	m_curl.setOpt(CURLOPT_URL, m_address.data());
+	m_curl.setOpt(CURLOPT_URL, url_addr.data());
 	m_curl.setOpt(CURLOPT_POST, 1L);
 	m_curl.setOpt(CURLOPT_TIMEOUT, 2L);
 
-	const auto escaped_field_data = m_curl.escape(packed_msg);
+	const auto escaped_field_data = m_curl.escape(json_dump);
 	const std::string post_field = getPostField("message", escaped_field_data);
 
 	m_curl.setOpt(CURLOPT_POSTFIELDS, post_field.data());
@@ -24,12 +24,12 @@ CURLcode HttpClient::post(const std::string &packed_msg) {
   return CURLE_OK;
 }
 
-CURLcode HttpClient::postAndGetReply(const std::string &msg, nlohmann::json &response_json) {
+CURLcode HttpClient::postAndGetReply(const std::string &url_addr, const std::string &json_dump, nlohmann::json &response_json) {
   try {
-	m_curl.setOpt(CURLOPT_URL, m_address.data());
+	m_curl.setOpt(CURLOPT_URL, url_addr.data());
 	m_curl.setOpt(CURLOPT_POST, 1L);
 
-	const auto escaped_filed_data = m_curl.escape(msg);
+	const auto escaped_filed_data = m_curl.escape(json_dump);
 	const std::string post_field = getPostField("message", escaped_filed_data);
 
 	m_curl.setOpt(CURLOPT_POSTFIELDS, post_field.data());
@@ -49,18 +49,6 @@ CURLcode HttpClient::postAndGetReply(const std::string &msg, nlohmann::json &res
   }
 
   return CURLE_OK;
-}
-
-bool HttpClient::checkServStatus() {
-  try {
-	m_curl.setOpt(CURLOPT_URL, m_address.data());
-	m_curl.setOpt(CURLOPT_FAILONERROR, 1L);
-
-	m_curl.perform();
-  } catch (curlpp::EasyException &err) {
-	return false;
-  }
-  return true;
 }
 
 std::string HttpClient::getPostField(const std::string &key, const std::string &value) {

--- a/network/http_client.hpp
+++ b/network/http_client.hpp
@@ -8,15 +8,10 @@ namespace net{
 
 class HttpClient {
 public:
-  HttpClient() = delete;
-  HttpClient(const std::string &ip, const std::string &port){
-    m_address = ip + ":" + port;
-  };
-  explicit HttpClient(const std::string &url_address) : m_address(url_address) {};
+  HttpClient() = default;
 
-  CURLcode post(const std::string &packed_msg);
-  CURLcode postAndGetReply(const std::string &msg, nlohmann::json &response_json);
-  bool checkServStatus();
+  CURLcode post(const std::string &url_addr, const std::string &json_dump);
+  CURLcode postAndGetReply(const std::string &url_addr, const std::string &json_dump, nlohmann::json &response_json);
 
 private:
   std::string getPostField(const std::string &key, const std::string &value);
@@ -24,7 +19,6 @@ private:
 							  std::string *out);
 
   curlpp::Easy m_curl;
-  std::string m_address;
 };
 
 }

--- a/tests/httpclient_test.cpp
+++ b/tests/httpclient_test.cpp
@@ -41,17 +41,17 @@ BOOST_AUTO_TEST_SUITE(Test_HttpClient)
 
   BOOST_AUTO_TEST_CASE(Post) {
     this_thread::sleep_for(chrono::seconds(2));
-    HttpClient http_client("localhost:8080/string");
+    HttpClient http_client;
 
-  	BOOST_CHECK_EQUAL(http_client.post(SAMPLE_JSON_REQ.dump()), 0);
+  	BOOST_CHECK_EQUAL(http_client.post("localhost:8080/string", SAMPLE_JSON_REQ.dump()), 0);
   }
 
   BOOST_AUTO_TEST_CASE(PostAndGetReply){
-  	HttpClient http_client("localhost:8080/string");
+  	HttpClient http_client;
 
 	nlohmann::json reply_json;
 
-	BOOST_CHECK_EQUAL(http_client.postAndGetReply(SAMPLE_JSON_REQ.dump(), reply_json), 0);
+	BOOST_CHECK_EQUAL(http_client.postAndGetReply("localhost:8080/string",SAMPLE_JSON_REQ.dump(), reply_json), 0);
 	BOOST_CHECK_EQUAL(reply_json, SAMPLE_JSON_RES);
 
   }


### PR DESCRIPTION
- HttpClient 객체 생성시 인자를 받지 않고 생성하도록 함.
- post, postAndGetReply 에서 url address를 받아 해당 주소로 post 하도록
수정
- checkServStatus() 함수 삭제 ( 사용하지 않음 )

- HttpClient Unit-test 수정