### PR TITLE
 # ADD - Tracker로 부터 Node(Merger) 정보 받아오는 함수 추가

### DIFF
--- a/network/config/network_config.hpp
+++ b/network/config/network_config.hpp
@@ -20,13 +20,14 @@ constexpr auto PERIODIC_REFRESH_TIMER = std::chrono::seconds(6);
 constexpr auto BUCKET_INACTIVE_TIME_BEFORE_REFRESH = std::chrono::seconds(1200);
 constexpr auto REQUEST_TIMEOUT = std::chrono::seconds(2);
 
-constexpr unsigned int MAX_THREAD_SIZE = 10;
-
-constexpr size_t KEEP_BROADCAST_MSG_TIME = 180;
+constexpr size_t GET_NODE_FROM_TRACKER_INTERVAL = 60; //minutes
+constexpr size_t KEEP_BROADCAST_MSG_TIME = 180; //seconds
+constexpr int MAX_NODE_INFO_FROM_TRACKER = 100;
 
 //TODO : 임시적으로 사용. 변경될 것.
 const std::string DEFAULT_PORT_NUM = "43234";
 const std::string IP_ADDRESS = "127.0.0.1";
+const std::string TRACKER_URL = "127.0.0.1:8080/nodeinfo";
 
 //TODO : MERGER의 ID를 GA로 받아 올 수 있을때 사용치 않을것. (ID : TEST-MERGER-ID-1TEST-MERGER-ID-1 )
 const std::string ID_BASE64 = "VEVTVC1NRVJHRVItSUQtMVRFU1QtTUVSR0VSLUlELTE=";

--- a/network/network_engine.cpp
+++ b/network/network_engine.cpp
@@ -15,7 +15,13 @@ NetworkEngine::NetworkEngine() {
 
 void NetworkEngine::setUp(){
   m_rpc_server.setUp(m_signer_conn_table, m_routing_table, m_broadcast_check_table);
-  m_sender.setUp(m_broadcast_check_table);
+  m_rpc_client.setUp(m_broadcast_check_table);
+}
+
+void NetworkEngine::bootStrap() {
+  getNodeInfoFromTracker();
+
+  //TODO : BootStrap 단계에서 해야할 일 추가적으로 필요.
 }
 
 void NetworkEngine::run() {
@@ -26,7 +32,7 @@ void NetworkEngine::run() {
 
 void NetworkEngine::pingTask(const Node& node) {
   auto endpoint = node.getEndpoint();
-  PongData pong = m_sender.pingReq(endpoint.address,endpoint.port);
+  PongData pong = m_rpc_client.pingReq(endpoint.address,endpoint.port);
   if(!pong.status.ok()){
     bool evicted = m_routing_table->peerTimedOut(node);
     if(!evicted)
@@ -42,7 +48,7 @@ void NetworkEngine::findNeighborsTask(const IdType &id,
   for(auto &target : target_list){
 	auto endpoint = target.getEndpoint();
 
-	NeighborsData recv_data = m_sender.findNodeReq(endpoint.address, endpoint.port, id);
+	NeighborsData recv_data = m_rpc_client.findNodeReq(endpoint.address, endpoint.port, id);
 	if(!recv_data.status.ok()){
 	  bool evicted = m_routing_table->peerTimedOut(target);
 	  if(!evicted)
@@ -110,6 +116,31 @@ void NetworkEngine::refreshBroadcastTable(){
   }
 }
 
+void NetworkEngine::getNodeInfoFromTracker(int max_node_info) {
+
+  //TODO : post 내용 및 post에 대한 답변에 항목들은 변경 될 것.
+  nlohmann::json request_json, response_json;
+
+  request_json["id"] = MY_ID;
+  request_json["ip"] = IP_ADDRESS;
+  request_json["port"] = DEFAULT_PORT_NUM;
+  request_json["max_node"] = max_node_info; //Tracker에게 요청 할 최대 node 수
+
+  m_http_client.postAndGetReply(TRACKER_URL, request_json.dump(), response_json);
+
+  if(response_json.find("nodes") != response_json.end()){
+   	 for(auto &node_info : response_json["nodes"]){
+   	    // TODO : json 객체 에서 항목을 읽어 올 때 문제가 생길 수 있으므로
+   	    // 안전한 방법으로 수정 할 것.
+		auto id = node_info["id"].get<std::string>();
+		auto ip = node_info["ip"].get<std::string>();
+		auto port = node_info["port"].get<std::string>();
+
+		Node node(Hash<160>::sha1(id), id, ip, port);
+		m_routing_table->addPeer(std::move(node));
+   	 }
+  }
+}
 
 }
 }

--- a/network/network_engine.hpp
+++ b/network/network_engine.hpp
@@ -1,6 +1,7 @@
 #pragma once
 #include "rpc_server.hpp"
 #include "rpc_client.hpp"
+#include "http_client.hpp"
 #include "config/network_config.hpp"
 namespace gruut {
 namespace net {
@@ -15,6 +16,8 @@ public:
 
   ~NetworkEngine() = default;
 
+  void setUp();
+  void bootStrap();
   void run();
 
 private:
@@ -22,16 +25,17 @@ private:
   std::shared_ptr<RoutingTable> m_routing_table;
   std::shared_ptr<BroadcastMsgTable> m_broadcast_check_table;
 
-  RpcClient m_sender;
+  RpcClient m_rpc_client;
+  HttpClient m_http_client;
   RpcServer m_rpc_server;
 
-  void setUp();
   void pingTask(const Node &node);
   void findNeighborsTask(const IdType &id, const HashedIdType &hashed_id);
   void refreshBuckets();
   void scheduleRefreshBuckets();
-
   void refreshBroadcastTable();
+
+  void getNodeInfoFromTracker(int max_node = MAX_NODE_INFO_FROM_TRACKER);
 
 };
 


### PR DESCRIPTION
 # 추가사항
- NetworkEngine 객체에 getNodeInfoFromTracker() 추가
- Tracker로 부터 Node(merger) 정보를 받아와 Routing table 을 업데이트
하도록 함

 # 해야할 일
- 해당 task 는 bootStrap 단계서 실행될 것이고, 주기적으로 실행될 것.
- 요청시 Post 하는 내용 및 받아올 내용은 수정 될 것.(현재 임시로 임의의
항목)